### PR TITLE
Migrated `RequestStatus` from `interface` to `sealed class`

### DIFF
--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/CategoriesScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/CategoriesScreenTest.kt
@@ -13,7 +13,6 @@ import xelagurd.socialdating.MainActivity
 import xelagurd.socialdating.R
 import xelagurd.socialdating.data.model.Category
 import xelagurd.socialdating.onNodeWithTagId
-import xelagurd.socialdating.onNodeWithTextId
 import xelagurd.socialdating.ui.screen.CategoriesScreenComponent
 import xelagurd.socialdating.ui.state.CategoriesUiState
 import xelagurd.socialdating.ui.state.RequestStatus
@@ -33,7 +32,7 @@ class CategoriesScreenTest {
     }
 
     @Test
-    fun categoriesScreen_loadingStatusAndEmptyData_loadingIndicator() {
+    fun categoriesScreen_loadingStateAndEmptyData_loadingIndicator() {
         val categoriesUiState = CategoriesUiState()
 
         setContentToCategoriesBody(categoriesUiState)
@@ -42,25 +41,31 @@ class CategoriesScreenTest {
     }
 
     @Test
-    fun categoriesScreen_offlineStatusAndEmptyData_offlineText() {
-        val categoriesUiState = CategoriesUiState(dataRequestStatus = RequestStatus.ERROR)
+    fun categoriesScreen_errorStateAndEmptyData_errorText() {
+        val errorText = "Error Text"
+        val categoriesUiState = CategoriesUiState(
+            dataRequestStatus = RequestStatus.ERROR(errorText)
+        )
 
         setContentToCategoriesBody(categoriesUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test
-    fun categoriesScreen_onlineStatusAndEmptyData_onlineText() {
-        val categoriesUiState = CategoriesUiState(dataRequestStatus = RequestStatus.SUCCESS)
+    fun categoriesScreen_failureStateAndEmptyData_failureText() {
+        val failureText = "Failure Text"
+        val categoriesUiState = CategoriesUiState(
+            dataRequestStatus = RequestStatus.FAILURE(failureText)
+        )
 
         setContentToCategoriesBody(categoriesUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_data).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun categoriesScreen_loadingStatusAndData_displayedData() {
+    fun categoriesScreen_loadingStateAndData_displayedData() {
         val categoriesUiState = CategoriesUiState(
             entities = listOf(Category(1, "Category1")),
             dataRequestStatus = RequestStatus.LOADING
@@ -70,17 +75,27 @@ class CategoriesScreenTest {
     }
 
     @Test
-    fun categoriesScreen_offlineStatusAndData_displayedData() {
+    fun categoriesScreen_errorStateAndData_displayedData() {
         val categoriesUiState = CategoriesUiState(
             entities = listOf(Category(1, "Category1")),
-            dataRequestStatus = RequestStatus.ERROR
+            dataRequestStatus = RequestStatus.ERROR()
         )
 
         assertDataIsDisplayed(categoriesUiState)
     }
 
     @Test
-    fun categoriesScreen_onlineStatusAndData_displayedData() {
+    fun categoriesScreen_failureStateAndData_displayedData() {
+        val categoriesUiState = CategoriesUiState(
+            entities = listOf(Category(1, "Category1")),
+            dataRequestStatus = RequestStatus.FAILURE()
+        )
+
+        assertDataIsDisplayed(categoriesUiState)
+    }
+
+    @Test
+    fun categoriesScreen_successStateAndData_displayedData() {
         val categoriesUiState = CategoriesUiState(
             entities = listOf(Category(1, "Category1")),
             dataRequestStatus = RequestStatus.SUCCESS

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/LoginScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/LoginScreenTest.kt
@@ -3,6 +3,7 @@ package xelagurd.socialdating.tests
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -42,7 +43,7 @@ class LoginScreenTest {
     }
 
     @Test
-    fun loginScreen_loadingStatus_loadingIndicator() {
+    fun loginScreen_loadingState_loadingIndicator() {
         val loginUiState = LoginUiState(actionRequestStatus = RequestStatus.LOADING)
 
         setContentToLoginBody(loginUiState)
@@ -51,21 +52,23 @@ class LoginScreenTest {
     }
 
     @Test
-    fun loginScreen_failedStatus_failedText() {
-        val loginUiState = LoginUiState(actionRequestStatus = RequestStatus.FAILED)
+    fun loginScreen_failureState_failureText() {
+        val failureText = "Failure Text"
+        val loginUiState = LoginUiState(actionRequestStatus = RequestStatus.FAILURE(failureText))
 
         setContentToLoginBody(loginUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.failed_login).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun loginScreen_errorStatus_errorText() {
-        val loginUiState = LoginUiState(actionRequestStatus = RequestStatus.ERROR)
+    fun loginScreen_errorState_errorText() {
+        val errorText = "Error Text"
+        val loginUiState = LoginUiState(actionRequestStatus = RequestStatus.ERROR(errorText))
 
         setContentToLoginBody(loginUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/ProfileScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/ProfileScreenTest.kt
@@ -37,7 +37,7 @@ class ProfileScreenTest {
     }
 
     @Test
-    fun profileScreen_loadingStatusAndEmptyData_loadingIndicator() {
+    fun profileScreen_loadingStateAndEmptyData_loadingIndicator() {
         val profileUiState = ProfileUiState()
 
         setContentToProfileBody(profileUiState)
@@ -46,25 +46,29 @@ class ProfileScreenTest {
     }
 
     @Test
-    fun profileScreen_offlineStatusAndEmptyData_offlineText() {
-        val profileUiState = ProfileUiState(dataRequestStatus = RequestStatus.ERROR)
+    fun profileScreen_errorStateAndEmptyData_errorText() {
+        val errorText = "Error Text"
+        val profileUiState = ProfileUiState(dataRequestStatus = RequestStatus.ERROR(errorText))
 
         setContentToProfileBody(profileUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test
-    fun profileScreen_onlineStatusAndEmptyData_onlineText() {
-        val profileUiState = ProfileUiState(dataRequestStatus = RequestStatus.SUCCESS)
+    fun profileScreen_failureStateAndEmptyData_failureText() {
+        val failureText = "Failure Text"
+        val profileUiState = ProfileUiState(
+            dataRequestStatus = RequestStatus.FAILURE(failureText)
+        )
 
         setContentToProfileBody(profileUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_data).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun profileScreen_loadingStatusAndData_displayedData() {
+    fun profileScreen_loadingStateAndData_displayedData() {
         val profileUiState = ProfileUiState(
             entity = User(
                 1, "User1", Gender.MALE, "username1", "password1",
@@ -77,20 +81,33 @@ class ProfileScreenTest {
     }
 
     @Test
-    fun profileScreen_offlineStatusAndData_displayedData() {
+    fun profileScreen_errorStateAndData_displayedData() {
         val profileUiState = ProfileUiState(
             entity = User(
                 1, "User1", Gender.MALE, "username1", "password1",
                 "email1@gmail.com", 30, "Moscow", Purpose.ALL_AT_ONCE, 50
             ),
-            dataRequestStatus = RequestStatus.ERROR
+            dataRequestStatus = RequestStatus.ERROR()
         )
 
         assertDataIsDisplayed(profileUiState)
     }
 
     @Test
-    fun profileScreen_onlineStatusAndData_displayedData() {
+    fun profileScreen_failureStateAndData_displayedData() {
+        val profileUiState = ProfileUiState(
+            entity = User(
+                1, "User1", Gender.MALE, "username1", "password1",
+                "email1@gmail.com", 30, "Moscow", Purpose.ALL_AT_ONCE, 50
+            ),
+            dataRequestStatus = RequestStatus.FAILURE()
+        )
+
+        assertDataIsDisplayed(profileUiState)
+    }
+
+    @Test
+    fun profileScreen_successStateAndData_displayedData() {
         val profileUiState = ProfileUiState(
             entity = User(
                 1, "User1", Gender.MALE, "username1", "password1",

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/ProfileStatisticsScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/ProfileStatisticsScreenTest.kt
@@ -17,7 +17,6 @@ import xelagurd.socialdating.data.model.additional.UserCategoryWithData
 import xelagurd.socialdating.data.model.additional.UserDefiningThemeWithData
 import xelagurd.socialdating.onNodeWithContentDescriptionId
 import xelagurd.socialdating.onNodeWithTagId
-import xelagurd.socialdating.onNodeWithTextId
 import xelagurd.socialdating.ui.screen.ProfileStatisticsScreenComponent
 import xelagurd.socialdating.ui.state.ProfileStatisticsUiState
 import xelagurd.socialdating.ui.state.RequestStatus
@@ -37,7 +36,7 @@ class ProfileStatisticsScreenTest {
     }
 
     @Test
-    fun profileStatisticsScreen_loadingStatusAndEmptyData_loadingIndicator() {
+    fun profileStatisticsScreen_loadingStateAndEmptyData_loadingIndicator() {
         val profileStatisticsUiState = ProfileStatisticsUiState()
 
         setContentToProfileStatisticsBody(profileStatisticsUiState)
@@ -46,27 +45,31 @@ class ProfileStatisticsScreenTest {
     }
 
     @Test
-    fun profileStatisticsScreen_offlineStatusAndEmptyData_offlineText() {
-        val profileStatisticsUiState =
-            ProfileStatisticsUiState(dataRequestStatus = RequestStatus.ERROR)
+    fun profileStatisticsScreen_errorStateAndEmptyData_errorText() {
+        val errorText = "Error Text"
+        val profileStatisticsUiState = ProfileStatisticsUiState(
+            dataRequestStatus = RequestStatus.ERROR(errorText)
+        )
 
         setContentToProfileStatisticsBody(profileStatisticsUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test
-    fun profileStatisticsScreen_onlineStatusAndEmptyData_onlineText() {
-        val profileStatisticsUiState =
-            ProfileStatisticsUiState(dataRequestStatus = RequestStatus.SUCCESS)
+    fun profileStatisticsScreen_failureStateAndEmptyData_failureText() {
+        val failureText = "Failure Text"
+        val profileStatisticsUiState = ProfileStatisticsUiState(
+            dataRequestStatus = RequestStatus.FAILURE(failureText)
+        )
 
         setContentToProfileStatisticsBody(profileStatisticsUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_data).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun profileStatisticsScreen_loadingStatusAndData_displayedData() {
+    fun profileStatisticsScreen_loadingStateAndData_displayedData() {
         val profileStatisticsUiState = ProfileStatisticsUiState(
             entities = listOf(UserCategoryWithData(1, 50, 50, 1, "Category1")),
             entityIdToData = mapOf(
@@ -79,20 +82,33 @@ class ProfileStatisticsScreenTest {
     }
 
     @Test
-    fun profileStatisticsScreen_offlineStatusAndData_displayedData() {
+    fun profileStatisticsScreen_errorStateAndData_displayedData() {
         val profileStatisticsUiState = ProfileStatisticsUiState(
             entities = listOf(UserCategoryWithData(1, 50, 50, 1, "Category1")),
             entityIdToData = mapOf(
                 1 to listOf(UserDefiningThemeWithData(1, 50, 50, 1, 1, "Theme1", "No", "Yes"))
             ),
-            dataRequestStatus = RequestStatus.ERROR
+            dataRequestStatus = RequestStatus.ERROR()
         )
 
         assertDataIsDisplayed(profileStatisticsUiState)
     }
 
     @Test
-    fun profileStatisticsScreen_onlineStatusAndData_displayedData() {
+    fun profileStatisticsScreen_failureStateAndData_displayedData() {
+        val profileStatisticsUiState = ProfileStatisticsUiState(
+            entities = listOf(UserCategoryWithData(1, 50, 50, 1, "Category1")),
+            entityIdToData = mapOf(
+                1 to listOf(UserDefiningThemeWithData(1, 50, 50, 1, 1, "Theme1", "No", "Yes"))
+            ),
+            dataRequestStatus = RequestStatus.FAILURE()
+        )
+
+        assertDataIsDisplayed(profileStatisticsUiState)
+    }
+
+    @Test
+    fun profileStatisticsScreen_successStateAndData_displayedData() {
         val profileStatisticsUiState = ProfileStatisticsUiState(
             entities = listOf(UserCategoryWithData(1, 50, 50, 1, "Category1")),
             entityIdToData = mapOf(

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/RegistrationScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/RegistrationScreenTest.kt
@@ -3,6 +3,7 @@ package xelagurd.socialdating.tests
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Before
@@ -45,7 +46,7 @@ class RegistrationScreenTest {
     }
 
     @Test
-    fun registrationScreen_loadingStatus_loadingIndicator() {
+    fun registrationScreen_loadingState_loadingIndicator() {
         val registrationUiState = RegistrationUiState(actionRequestStatus = RequestStatus.LOADING)
 
         setContentToRegistrationBody(registrationUiState)
@@ -54,21 +55,27 @@ class RegistrationScreenTest {
     }
 
     @Test
-    fun registrationScreen_failedStatus_failedText() {
-        val registrationUiState = RegistrationUiState(actionRequestStatus = RequestStatus.FAILED)
+    fun registrationScreen_failureState_failureText() {
+        val failureText = "Failure Text"
+        val registrationUiState = RegistrationUiState(
+            actionRequestStatus = RequestStatus.FAILURE(failureText)
+        )
 
         setContentToRegistrationBody(registrationUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.failed_registration).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun registrationScreen_errorStatus_errorText() {
-        val registrationUiState = RegistrationUiState(actionRequestStatus = RequestStatus.ERROR)
+    fun registrationScreen_errorState_errorText() {
+        val errorText = "Error Text"
+        val registrationUiState = RegistrationUiState(
+            actionRequestStatus = RequestStatus.ERROR(errorText)
+        )
 
         setContentToRegistrationBody(registrationUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/SettingsScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/SettingsScreenTest.kt
@@ -39,21 +39,12 @@ class SettingsScreenTest {
     }
 
     @Test
-    fun settingsScreen_loadingStatus_loadingIndicator() {
+    fun settingsScreen_loadingState_loadingIndicator() {
         val settingsUiState = SettingsUiState(actionRequestStatus = RequestStatus.LOADING)
 
         setContentToSettingsBody(settingsUiState)
 
         composeTestRule.onNodeWithTagId(R.string.loading).assertIsDisplayed()
-    }
-
-    @Test
-    fun settingsScreen_errorStatus_errorText() {
-        val settingsUiState = SettingsUiState(actionRequestStatus = RequestStatus.ERROR)
-
-        setContentToSettingsBody(settingsUiState)
-
-        composeTestRule.onNodeWithTextId(R.string.unknown_error).assertIsDisplayed()
     }
 
     private fun assertContentIsDisplayed(settingsUiState: SettingsUiState) {

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/StatementAddingScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/StatementAddingScreenTest.kt
@@ -39,13 +39,26 @@ class StatementAddingScreenTest {
     }
 
     @Test
-    fun statementAddingScreen_emptyDefiningThemes_assertContentIsDisplayed() {
+    fun statementAddingScree_loadingStateAndEmptyDefiningThemes_assertContentIsDisplayed() {
         val statementAddingUiState = StatementAddingUiState(
-            dataRequestStatus = RequestStatus.SUCCESS
+            dataRequestStatus = RequestStatus.LOADING
         )
 
         assertContentIsDisplayed(statementAddingUiState)
-        composeTestRule.onNodeWithTextId(R.string.no_data).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTagId(R.string.loading).assertIsDisplayed()
+    }
+
+    @Test
+    fun statementAddingScree_failureStateAndEmptyDefiningThemes_assertContentIsDisplayed() {
+        val failureText = "Failure Text"
+        val statementAddingUiState = StatementAddingUiState(
+            dataRequestStatus = RequestStatus.FAILURE(failureText)
+        )
+
+        assertContentIsDisplayed(statementAddingUiState)
+
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
@@ -75,7 +88,7 @@ class StatementAddingScreenTest {
     }
 
     @Test
-    fun statementAddingScreen_loadingStatus_loadingIndicator() {
+    fun statementAddingScreen_loadingState_loadingIndicator() {
         val statementAddingUiState = StatementAddingUiState(
             dataRequestStatus = RequestStatus.SUCCESS,
             actionRequestStatus = RequestStatus.LOADING
@@ -87,27 +100,29 @@ class StatementAddingScreenTest {
     }
 
     @Test
-    fun statementAddingScreen_failedStatus_failedText() {
+    fun statementAddingScreen_failureState_failureText() {
+        val failureText = "Failure Text"
         val statementAddingUiState = StatementAddingUiState(
             dataRequestStatus = RequestStatus.SUCCESS,
-            actionRequestStatus = RequestStatus.FAILED
+            actionRequestStatus = RequestStatus.FAILURE(failureText)
         )
 
         setContentToStatementAddingBody(statementAddingUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.failed_add_statement).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun statementAddingScreen_errorStatus_errorText() {
+    fun statementAddingScreen_errorState_errorText() {
+        val errorText = "Error Text"
         val statementAddingUiState = StatementAddingUiState(
             dataRequestStatus = RequestStatus.SUCCESS,
-            actionRequestStatus = RequestStatus.ERROR
+            actionRequestStatus = RequestStatus.ERROR(errorText)
         )
 
         setContentToStatementAddingBody(statementAddingUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/StatementsScreenTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/StatementsScreenTest.kt
@@ -15,7 +15,6 @@ import xelagurd.socialdating.checkEnabledButton
 import xelagurd.socialdating.data.model.Statement
 import xelagurd.socialdating.onNodeWithContentDescriptionId
 import xelagurd.socialdating.onNodeWithTagId
-import xelagurd.socialdating.onNodeWithTextId
 import xelagurd.socialdating.ui.screen.StatementsScreenComponent
 import xelagurd.socialdating.ui.state.RequestStatus
 import xelagurd.socialdating.ui.state.StatementsUiState
@@ -35,7 +34,7 @@ class StatementsScreenTest {
     }
 
     @Test
-    fun statementsScreen_loadingStatusAndEmptyData_loadingIndicator() {
+    fun statementsScreen_loadingStateAndEmptyData_loadingIndicator() {
         val statementsUiState = StatementsUiState()
 
         setContentToStatementsBody(statementsUiState)
@@ -44,25 +43,31 @@ class StatementsScreenTest {
     }
 
     @Test
-    fun statementsScreen_offlineStatusAndEmptyData_offlineText() {
-        val statementsUiState = StatementsUiState(dataRequestStatus = RequestStatus.ERROR)
+    fun statementsScreen_errorStateAndEmptyData_errorText() {
+        val errorText = "Error Text"
+        val statementsUiState = StatementsUiState(
+            dataRequestStatus = RequestStatus.ERROR(errorText)
+        )
 
         setContentToStatementsBody(statementsUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_internet_connection).assertIsDisplayed()
+        composeTestRule.onNodeWithText(errorText).assertIsDisplayed()
     }
 
     @Test
-    fun statementsScreen_onlineStatusAndEmptyData_onlineText() {
-        val statementsUiState = StatementsUiState(dataRequestStatus = RequestStatus.SUCCESS)
+    fun statementsScreen_failureStateAndEmptyData_failureText() {
+        val failureText = "Failure Text"
+        val statementsUiState = StatementsUiState(
+            dataRequestStatus = RequestStatus.FAILURE(failureText)
+        )
 
         setContentToStatementsBody(statementsUiState)
 
-        composeTestRule.onNodeWithTextId(R.string.no_data).assertIsDisplayed()
+        composeTestRule.onNodeWithText(failureText).assertIsDisplayed()
     }
 
     @Test
-    fun statementsScreen_loadingStatusAndData_displayedData() {
+    fun statementsScreen_loadingStateAndData_displayedData() {
         val statementsUiState = StatementsUiState(
             entities = listOf(Statement(1, "Statement1", true, 1, 1)),
             dataRequestStatus = RequestStatus.LOADING
@@ -72,17 +77,27 @@ class StatementsScreenTest {
     }
 
     @Test
-    fun statementsScreen_offlineStatusAndData_displayedData() {
+    fun statementsScreen_errorStateAndData_displayedData() {
         val statementsUiState = StatementsUiState(
             entities = listOf(Statement(1, "Statement1", true, 1, 1)),
-            dataRequestStatus = RequestStatus.ERROR
+            dataRequestStatus = RequestStatus.ERROR()
         )
 
         assertDataIsDisplayed(statementsUiState)
     }
 
     @Test
-    fun statementsScreen_onlineStatusAndData_displayedData() {
+    fun statementsScreen_failureStateAndData_displayedData() {
+        val statementsUiState = StatementsUiState(
+            entities = listOf(Statement(1, "Statement1", true, 1, 1)),
+            dataRequestStatus = RequestStatus.FAILURE()
+        )
+
+        assertDataIsDisplayed(statementsUiState)
+    }
+
+    @Test
+    fun statementsScreen_successStateAndData_displayedData() {
         val statementsUiState = StatementsUiState(
             entities = listOf(Statement(1, "Statement1", true, 1, 1)),
             dataRequestStatus = RequestStatus.SUCCESS

--- a/client/app/src/androidTest/java/xelagurd/socialdating/tests/TopBarTest.kt
+++ b/client/app/src/androidTest/java/xelagurd/socialdating/tests/TopBarTest.kt
@@ -38,7 +38,7 @@ class TopBarTest {
     }
 
     @Test
-    fun topBar_loadingStatus_loadingText() {
+    fun topBar_loadingState_loadingText() {
         setContentToAppTopBar(RequestStatus.LOADING)
 
         composeTestRule.onNodeWithContentDescriptionId(R.string.back_button).assertIsNotDisplayed()
@@ -47,8 +47,8 @@ class TopBarTest {
     }
 
     @Test
-    fun topBar_offlineStatus_offlineTextWithRefresh() {
-        setContentToAppTopBar(RequestStatus.ERROR)
+    fun topBar_errorState_offlineTextWithRefresh() {
+        setContentToAppTopBar(RequestStatus.ERROR())
 
         composeTestRule.onNodeWithContentDescriptionId(R.string.back_button).assertIsNotDisplayed()
         composeTestRule.onNodeWithContentDescriptionId(R.string.refresh).assertIsDisplayed()
@@ -56,7 +56,7 @@ class TopBarTest {
     }
 
     @Test
-    fun topBar_onlineStatus_onlineText() {
+    fun topBar_successState_onlineText() {
         setContentToAppTopBar(RequestStatus.SUCCESS)
 
         composeTestRule.onNodeWithContentDescriptionId(R.string.back_button).assertIsNotDisplayed()

--- a/client/app/src/main/java/xelagurd/socialdating/SocialDatingApp.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/SocialDatingApp.kt
@@ -71,7 +71,7 @@ fun AppTopBar(
                                 when (dataRequestStatus) {
                                     RequestStatus.SUCCESS -> R.string.online
                                     RequestStatus.UNDEFINED, RequestStatus.LOADING -> R.string.loading
-                                    RequestStatus.FAILED, RequestStatus.ERROR -> R.string.offline
+                                    is RequestStatus.FAILURE, is RequestStatus.ERROR -> R.string.offline
                                 }
                             ),
                             style = MaterialTheme.typography.titleMedium,
@@ -129,7 +129,7 @@ fun AppTopBarOfflinePreview() {
     AppTheme {
         AppTopBar(
             title = stringResource(CategoriesDestination.titleRes),
-            dataRequestStatus = RequestStatus.ERROR,
+            dataRequestStatus = RequestStatus.ERROR(),
             refreshAction = {},
             navigateUp = {}
         )

--- a/client/app/src/main/java/xelagurd/socialdating/ui/screen/AppComponents.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/screen/AppComponents.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import xelagurd.socialdating.R
 import xelagurd.socialdating.data.model.DataEntity
 import xelagurd.socialdating.ui.state.DataEntityUiState
 import xelagurd.socialdating.ui.state.DataListUiState
@@ -108,8 +106,9 @@ private fun DataRequestStatusComponent(
 ) {
     when (dataRequestStatus) {
         RequestStatus.UNDEFINED, RequestStatus.LOADING -> AppLoadingIndicator()
-        RequestStatus.FAILED, RequestStatus.ERROR -> AppLargeTitleText(text = stringResource(R.string.no_internet_connection))
-        RequestStatus.SUCCESS -> AppLargeTitleText(text = stringResource(R.string.no_data))
+        is RequestStatus.FAILURE -> AppLargeTitleText(text = dataRequestStatus.failureText)
+        is RequestStatus.ERROR -> AppLargeTitleText(text = dataRequestStatus.errorText)
+        RequestStatus.SUCCESS -> {}
     }
 }
 
@@ -117,8 +116,6 @@ private fun DataRequestStatusComponent(
 fun ComponentWithActionRequestStatus(
     actionRequestStatus: RequestStatus,
     onSuccess: () -> Unit,
-    failedText: String,
-    errorText: String,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable () -> Unit
 ) {
@@ -130,9 +127,7 @@ fun ComponentWithActionRequestStatus(
         content()
         ActionRequestStatusComponent(
             actionRequestStatus = actionRequestStatus,
-            onSuccess = onSuccess,
-            failedText = failedText,
-            errorText = errorText
+            onSuccess = onSuccess
         )
     }
 }
@@ -140,9 +135,7 @@ fun ComponentWithActionRequestStatus(
 @Composable
 private inline fun ActionRequestStatusComponent(
     actionRequestStatus: RequestStatus,
-    onSuccess: () -> Unit,
-    failedText: String,
-    errorText: String
+    onSuccess: () -> Unit
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -152,8 +145,8 @@ private inline fun ActionRequestStatusComponent(
         when (actionRequestStatus) {
             RequestStatus.UNDEFINED -> {}
             RequestStatus.LOADING -> AppLoadingIndicator()
-            RequestStatus.FAILED -> AppLargeTitleText(failedText)
-            RequestStatus.ERROR -> AppLargeTitleText(errorText)
+            is RequestStatus.FAILURE -> AppLargeTitleText(actionRequestStatus.failureText)
+            is RequestStatus.ERROR -> AppLargeTitleText(actionRequestStatus.errorText)
             RequestStatus.SUCCESS -> onSuccess()
         }
     }

--- a/client/app/src/main/java/xelagurd/socialdating/ui/screen/LoginScreen.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/screen/LoginScreen.kt
@@ -58,8 +58,6 @@ fun LoginScreenComponent(
         ComponentWithActionRequestStatus(
             actionRequestStatus = loginUiState.actionRequestStatus,
             onSuccess = onSuccessLogin,
-            failedText = stringResource(R.string.failed_login),
-            errorText = stringResource(R.string.no_internet_connection),
             contentPadding = innerPadding
         ) {
             LoginDetailsBody(

--- a/client/app/src/main/java/xelagurd/socialdating/ui/screen/RegistrationScreen.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/screen/RegistrationScreen.kt
@@ -69,8 +69,6 @@ fun RegistrationScreenComponent(
         ComponentWithActionRequestStatus(
             actionRequestStatus = registrationUiState.actionRequestStatus,
             onSuccess = onSuccessRegistration,
-            failedText = stringResource(R.string.failed_registration),
-            errorText = stringResource(R.string.no_internet_connection),
             contentPadding = innerPadding
         ) {
             RegistrationDetailsBody(

--- a/client/app/src/main/java/xelagurd/socialdating/ui/screen/SettingsScreen.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/screen/SettingsScreen.kt
@@ -58,8 +58,6 @@ fun SettingsScreenComponent(
         ComponentWithActionRequestStatus(
             actionRequestStatus = settingsUiState.actionRequestStatus,
             onSuccess = onSuccessLogout,
-            failedText = "",
-            errorText = stringResource(R.string.unknown_error),
             contentPadding = innerPadding
         ) {
             SettingsDetailsBody(

--- a/client/app/src/main/java/xelagurd/socialdating/ui/screen/StatementAddingScreen.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/screen/StatementAddingScreen.kt
@@ -74,8 +74,6 @@ fun StatementAddingScreenComponent(
         ComponentWithActionRequestStatus(
             actionRequestStatus = statementAddingUiState.actionRequestStatus,
             onSuccess = onSuccessStatementAdding,
-            failedText = stringResource(R.string.failed_add_statement),
-            errorText = stringResource(R.string.no_internet_connection),
             contentPadding = innerPadding
         ) {
             StatementDetailsBody(

--- a/client/app/src/main/java/xelagurd/socialdating/ui/state/RequestStatus.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/state/RequestStatus.kt
@@ -1,11 +1,11 @@
 package xelagurd.socialdating.ui.state
 
-enum class RequestStatus {
-    SUCCESS,
-    LOADING,
-    ERROR,
-    FAILED,
-    UNDEFINED;
+sealed class RequestStatus {
+    object SUCCESS : RequestStatus()
+    object LOADING : RequestStatus()
+    data class ERROR(val errorText: String = "") : RequestStatus()
+    data class FAILURE(val failureText: String = "") : RequestStatus()
+    object UNDEFINED : RequestStatus()
 
-    fun isAllowedRefresh() = this == ERROR || this == FAILED
+    fun isAllowedRefresh() = this is ERROR || this is FAILURE
 }

--- a/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/LoginViewModel.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/LoginViewModel.kt
@@ -7,16 +7,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import android.content.Context
 import android.util.Log
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.PasswordCredential
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.mindrot.jbcrypt.BCrypt
 import xelagurd.socialdating.AccountManager
 import xelagurd.socialdating.PreferencesRepository
+import xelagurd.socialdating.R
 import xelagurd.socialdating.data.fake.FAKE_SERVER_LATENCY
+import xelagurd.socialdating.data.fake.FakeDataSource
 import xelagurd.socialdating.data.local.repository.LocalUsersRepository
 import xelagurd.socialdating.data.model.details.LoginDetails
 import xelagurd.socialdating.data.remote.repository.RemoteUsersRepository
@@ -25,6 +29,7 @@ import xelagurd.socialdating.ui.state.RequestStatus
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val remoteRepository: RemoteUsersRepository,
     private val localRepository: LocalUsersRepository,
     private val preferencesRepository: PreferencesRepository,
@@ -99,10 +104,26 @@ class LoginViewModel @Inject constructor(
 
                 _uiState.update { it.copy(actionRequestStatus = RequestStatus.SUCCESS) }
             } else {
-                _uiState.update { it.copy(actionRequestStatus = RequestStatus.FAILED) }
+                _uiState.update {
+                    it.copy(
+                        actionRequestStatus = RequestStatus.FAILURE(
+                            failureText = context.getString(R.string.failed_login)
+                        )
+                    )
+                }
             }
         } catch (_: IOException) {
-            _uiState.update { it.copy(actionRequestStatus = RequestStatus.ERROR) }
+            accountManager.saveCredentials(
+                LoginDetails(
+                    FakeDataSource.users[0].username,
+                    FakeDataSource.users[0].password
+                )
+            ) // TODO: remove after implementing server
+
+            localRepository.insertUser(FakeDataSource.users[0]) // TODO: remove after implementing server
+            preferencesRepository.saveCurrentUserId(FakeDataSource.users[0].id) // TODO: remove after implementing server
+
+            _uiState.update { it.copy(actionRequestStatus = RequestStatus.SUCCESS) } // TODO: Change to ERROR after implementing server
         }
     }
 }

--- a/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/ProfileViewModel.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/ProfileViewModel.kt
@@ -10,10 +10,13 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import xelagurd.socialdating.R
 import xelagurd.socialdating.data.fake.FAKE_SERVER_LATENCY
 import xelagurd.socialdating.data.local.repository.LocalUsersRepository
 import xelagurd.socialdating.data.remote.repository.RemoteUsersRepository
@@ -23,13 +26,14 @@ import xelagurd.socialdating.ui.state.RequestStatus
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     savedStateHandle: SavedStateHandle,
     private val remoteRepository: RemoteUsersRepository,
     private val localRepository: LocalUsersRepository
 ) : ViewModel() {
     private val userId: Int = checkNotNull(savedStateHandle[ProfileDestination.userId])
 
-    private val dataRequestStatusFlow = MutableStateFlow(RequestStatus.UNDEFINED)
+    private val dataRequestStatusFlow = MutableStateFlow<RequestStatus>(RequestStatus.UNDEFINED)
     private val userFlow = localRepository.getUser(userId).distinctUntilChanged()
 
     val uiState = combine(userFlow, dataRequestStatusFlow) { user, dataRequestStatus ->
@@ -55,11 +59,24 @@ class ProfileViewModel @Inject constructor(
                 delay(FAKE_SERVER_LATENCY) // FixMe: remove after implementing server
 
                 val remoteUser = remoteRepository.getUser(userId)
-                remoteUser?.let { localRepository.insertUser(it) }
 
-                dataRequestStatusFlow.update { RequestStatus.SUCCESS }
+                if (remoteUser != null) {
+                    localRepository.insertUser(remoteUser)
+
+                    dataRequestStatusFlow.update { RequestStatus.SUCCESS }
+                } else {
+                    dataRequestStatusFlow.update {
+                        RequestStatus.FAILURE(
+                            failureText = context.getString(R.string.no_data)
+                        )
+                    }
+                }
             } catch (_: IOException) {
-                dataRequestStatusFlow.update { RequestStatus.ERROR }
+                dataRequestStatusFlow.update {
+                    RequestStatus.ERROR(
+                        errorText = context.getString(R.string.no_internet_connection)
+                    )
+                }
             }
         }
     }

--- a/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/RegistrationViewModel.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/RegistrationViewModel.kt
@@ -7,12 +7,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.mindrot.jbcrypt.BCrypt
 import xelagurd.socialdating.AccountManager
 import xelagurd.socialdating.PreferencesRepository
+import xelagurd.socialdating.R
 import xelagurd.socialdating.data.fake.FAKE_SERVER_LATENCY
 import xelagurd.socialdating.data.fake.FakeDataSource
 import xelagurd.socialdating.data.local.repository.LocalUsersRepository
@@ -24,6 +27,7 @@ import xelagurd.socialdating.ui.state.RequestStatus
 
 @HiltViewModel
 class RegistrationViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val remoteRepository: RemoteUsersRepository,
     private val localRepository: LocalUsersRepository,
     private val preferencesRepository: PreferencesRepository,
@@ -61,7 +65,13 @@ class RegistrationViewModel @Inject constructor(
 
                     _uiState.update { it.copy(actionRequestStatus = RequestStatus.SUCCESS) }
                 } else {
-                    _uiState.update { it.copy(actionRequestStatus = RequestStatus.FAILED) }
+                    _uiState.update {
+                        it.copy(
+                            actionRequestStatus = RequestStatus.FAILURE(
+                                failureText = context.getString(R.string.failed_registration)
+                            )
+                        )
+                    }
                 }
             } catch (_: IOException) {
                 accountManager.saveCredentials(

--- a/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/SettingsViewModel.kt
+++ b/client/app/src/main/java/xelagurd/socialdating/ui/viewmodel/SettingsViewModel.kt
@@ -1,6 +1,5 @@
 package xelagurd.socialdating.ui.viewmodel
 
-import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,15 +22,11 @@ class SettingsViewModel @Inject constructor(
 
     fun logout() {
         viewModelScope.launch {
-            try {
-                _uiState.update { it.copy(actionRequestStatus = RequestStatus.LOADING) }
+            _uiState.update { it.copy(actionRequestStatus = RequestStatus.LOADING) }
 
-                preferencesRepository.saveCurrentUserId(-1)
+            preferencesRepository.saveCurrentUserId(-1)
 
-                _uiState.update { it.copy(actionRequestStatus = RequestStatus.SUCCESS) }
-            } catch (_: IOException) {
-                _uiState.update { it.copy(actionRequestStatus = RequestStatus.ERROR) }
-            }
+            _uiState.update { it.copy(actionRequestStatus = RequestStatus.SUCCESS) }
         }
     }
 }

--- a/client/app/src/test/java/xelagurd/socialdating/tests/RegistrationViewModelTest.kt
+++ b/client/app/src/test/java/xelagurd/socialdating/tests/RegistrationViewModelTest.kt
@@ -4,8 +4,10 @@ import java.io.IOException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import android.content.Context
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import junit.framework.TestCase.assertEquals
@@ -31,6 +33,7 @@ class RegistrationViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private val context: Context = mockk()
     private val remoteRepository: RemoteUsersRepository = mockk()
     private val localRepository: LocalUsersRepository = mockk()
     private val preferencesRepository: PreferencesRepository = mockk()
@@ -48,6 +51,7 @@ class RegistrationViewModelTest {
     @Before
     fun setup() {
         viewModel = RegistrationViewModel(
+            context,
             remoteRepository,
             localRepository,
             preferencesRepository,
@@ -79,7 +83,7 @@ class RegistrationViewModelTest {
         mockWrongData()
         advanceUntilIdle()
 
-        assertEquals(RequestStatus.FAILED, registrationUiState.actionRequestStatus)
+        assertEquals(RequestStatus.FAILURE(), registrationUiState.actionRequestStatus)
     }
 
     @Test
@@ -114,10 +118,12 @@ class RegistrationViewModelTest {
     }
 
     private fun mockWrongData() {
+        every { context.getString(any()) } returns ""
         coEvery { remoteRepository.registerUser(ofType<RegistrationDetails>()) } returns null
     }
 
     private fun mockDataWithoutInternet() {
+        every { context.getString(any()) } returns ""
         coEvery { remoteRepository.registerUser(ofType<RegistrationDetails>()) } throws IOException()
         coEvery {
             accountManager.saveCredentials(

--- a/client/app/src/test/java/xelagurd/socialdating/tests/SettingsViewModelTest.kt
+++ b/client/app/src/test/java/xelagurd/socialdating/tests/SettingsViewModelTest.kt
@@ -1,6 +1,5 @@
 package xelagurd.socialdating.tests
 
-import java.io.IOException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -34,41 +33,15 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun settingsViewModel_logoutWithInternet() = runTest {
+    fun settingsViewModel_logout() = runTest {
         viewModel.logout()
-        mockDataWithInternet()
+        mockData()
         advanceUntilIdle()
 
         assertEquals(RequestStatus.SUCCESS, settingsUiState.actionRequestStatus)
     }
 
-    @Test
-    fun settingsViewModel_logoutWithoutInternet() = runTest {
-        viewModel.logout()
-        mockDataWithoutInternet()
-        advanceUntilIdle()
-
-        assertEquals(RequestStatus.ERROR, settingsUiState.actionRequestStatus)
-    }
-
-    @Test
-    fun settingsViewModel_retryLogoutWithInternet() = runTest {
-        viewModel.logout()
-        mockDataWithoutInternet()
-        advanceUntilIdle()
-
-        mockDataWithInternet()
-        viewModel.logout()
-        advanceUntilIdle()
-
-        assertEquals(RequestStatus.SUCCESS, settingsUiState.actionRequestStatus)
-    }
-
-    private fun mockDataWithInternet() {
+    private fun mockData() {
         coEvery { preferencesRepository.saveCurrentUserId(-1) } just Runs
-    }
-
-    private fun mockDataWithoutInternet() {
-        coEvery { preferencesRepository.saveCurrentUserId(-1) } throws IOException()
     }
 }

--- a/client/app/src/test/java/xelagurd/socialdating/tests/StatementAddingViewModelTest.kt
+++ b/client/app/src/test/java/xelagurd/socialdating/tests/StatementAddingViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -32,6 +33,7 @@ class StatementAddingViewModelTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private val context: Context = mockk()
     private val savedStateHandle: SavedStateHandle = mockk()
     private val localDefiningThemesRepository: LocalDefiningThemesRepository = mockk()
     private val remoteStatementsRepository: RemoteStatementsRepository = mockk()
@@ -54,6 +56,7 @@ class StatementAddingViewModelTest {
         mockGeneralMethods()
 
         viewModel = StatementAddingViewModel(
+            context,
             savedStateHandle,
             localDefiningThemesRepository,
             remoteStatementsRepository,
@@ -86,7 +89,7 @@ class StatementAddingViewModelTest {
         mockWrongData()
         advanceUntilIdle()
 
-        assertEquals(RequestStatus.FAILED, statementAddingUiState.actionRequestStatus)
+        assertEquals(RequestStatus.FAILURE(), statementAddingUiState.actionRequestStatus)
     }
 
     @Test
@@ -126,10 +129,12 @@ class StatementAddingViewModelTest {
     }
 
     private fun mockWrongData() {
+        every { context.getString(any()) } returns ""
         coEvery { remoteStatementsRepository.statementAdding(statementDetails) } returns null
     }
 
     private fun mockDataWithoutInternet() {
+        every { context.getString(any()) } returns ""
         coEvery { remoteStatementsRepository.statementAdding(statementDetails) } throws IOException()
         coEvery { localStatementsRepository.insertStatement(FakeDataSource.newStatement) } just Runs // TODO: remove after implementing server
     }


### PR DESCRIPTION
### What's done:
- Migrated `RequestStatus` from `interface` to `sealed class`
- Supported `failureText` and `errorText` in `RequestStatus`